### PR TITLE
fix(facturx): add support for credit note invoice date

### DIFF
--- a/facturx/facturx.py
+++ b/facturx/facturx.py
@@ -206,8 +206,7 @@ class FacturX(object):
         # After children are processed, check if current element is empty
         if (
                 len(element) == 0 and
-                (element.text is None or not element.text.strip()) and
-                not element.attrib
+                (element.text is None or not element.text.strip())
         ):
             parent = element.getparent()
             if parent is not None:

--- a/facturx/flavors/factur-x/xml/en16931_fe.xml
+++ b/facturx/flavors/factur-x/xml/en16931_fe.xml
@@ -5,7 +5,7 @@
                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<rsm:ExchangedDocumentContext>
 		<ram:BusinessProcessSpecifiedDocumentContextParameter>
-			<ram:ID>B1</ram:ID>
+			<ram:ID>S1</ram:ID>
 		</ram:BusinessProcessSpecifiedDocumentContextParameter>
 		<ram:GuidelineSpecifiedDocumentContextParameter>
 			<ram:ID>urn:cen.eu:en16931:2017</ram:ID>
@@ -194,6 +194,9 @@
 			</ram:SpecifiedTradeSettlementHeaderMonetarySummation>
 			<ram:InvoiceReferencedDocument>
 				<ram:IssuerAssignedID></ram:IssuerAssignedID>
+				<ram:FormattedIssueDateTime>
+					<qdt:DateTimeString format="102"></qdt:DateTimeString>
+				</ram:FormattedIssueDateTime>
 			</ram:InvoiceReferencedDocument>
 		</ram:ApplicableHeaderTradeSettlement>
 	</rsm:SupplyChainTradeTransaction>

--- a/facturx/flavors/factur-x/xml/en16931_fe.xml
+++ b/facturx/flavors/factur-x/xml/en16931_fe.xml
@@ -163,21 +163,6 @@
 				  <udt:DateTimeString format="102"></udt:DateTimeString>
 				</ram:EndDateTime>
 		    </ram:BillingSpecifiedPeriod>
-			<ram:SpecifiedTradeAllowanceCharge>
-				<ram:ChargeIndicator>
-					<udt:Indicator>false</udt:Indicator>
-				</ram:ChargeIndicator>
-				<ram:CalculationPercent>0</ram:CalculationPercent>
-				<ram:BasisAmount>0</ram:BasisAmount>
-				<ram:ActualAmount>0</ram:ActualAmount>
-				<ram:Reason>-</ram:Reason>
-				<ram:CategoryTradeTax>
-					<ram:TypeCode>VAT</ram:TypeCode>
-					<ram:CategoryCode>S</ram:CategoryCode>
-					<ram:DueDateTypeCode></ram:DueDateTypeCode>
-					<ram:RateApplicablePercent>0</ram:RateApplicablePercent>
-				</ram:CategoryTradeTax>
-			</ram:SpecifiedTradeAllowanceCharge>
 			<ram:SpecifiedTradePaymentTerms>
 				<ram:Description></ram:Description>
 				<ram:DueDateDateTime>

--- a/facturx/flavors/fields.yml
+++ b/facturx/flavors/fields.yml
@@ -21,7 +21,7 @@ avoir_invoice_number:
     _required: false
 avoir_invoice_date:
     _path:
-        factur-x: /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:InvoiceReferencedDocument/ram:FormattedIssueDateTime
+        factur-x: /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:InvoiceReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString
     _required: false
 date:
     _path:
@@ -95,7 +95,7 @@ tva_due_code:
     _path:
         factur-x: //rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax/ram:DueDateTypeCode
     _required: false
-tva_rate:
+tva_rate_header:
     _path:
         factur-x: //rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent
     _required: false
@@ -277,13 +277,9 @@ line_total_amount:
     _path:
         factur-x: //rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:SpecifiedTradeSettlementLineMonetarySummation/ram:LineTotalAmount
     _required: false
-tva_rate2:
+tva_rate_applicable_trade_tax:
     _path:
         factur-x: //rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax/ram:RateApplicablePercent
-    _required: false
-tva_rate3:
-    _path:
-        factur-x: //rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeAllowanceCharge/ram:CategoryTradeTax/ram:RateApplicablePercent
     _required: false
 buyer_tva_intra:
     _path:

--- a/facturx/flavors/fields.yml
+++ b/facturx/flavors/fields.yml
@@ -19,6 +19,10 @@ avoir_invoice_number:
     _path:
         factur-x: /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:InvoiceReferencedDocument/ram:IssuerAssignedID
     _required: false
+avoir_invoice_date:
+    _path:
+        factur-x: /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:InvoiceReferencedDocument/ram:FormattedIssueDateTime
+    _required: false
 date:
     _path:
         factur-x: //rsm:ExchangedDocument/ram:IssueDateTime/udt:DateTimeString

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyfacturx"
-version = "2.0.0"
+version = "2.0.1"
 description = "Factur-X: electronic invoicing standard for France"
 readme = "README.md"
 license = "BSD-2-Clause"


### PR DESCRIPTION
- Add `avoir_invoice_date` field in `fields.yml` for credit note date mapping
- Update `en16931_fe.xml` to include `FormattedIssueDateTime` element
- Change business process ID from `B1` to `S1` for credit note compatibility